### PR TITLE
remove macOS as most of the time it's just waiting for the runner to be picked up

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         node: ['16.x', '18.x']
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+        os: [ubuntu-latest, windows-latest]
 
     steps:
       - name: Checkout repo


### PR DESCRIPTION
This PR is to just remove the macOS from the GitHub workflow, as most of the time it's just waiting for it to be picked up.