### PR TITLE
use setRoomPeerDescriptionsById instead of setRoomPeers

### DIFF
--- a/src/VCSWebRenderer.ts
+++ b/src/VCSWebRenderer.ts
@@ -11,6 +11,7 @@ import type {
   VCSCallbacks,
   Params,
   Merge,
+  VCSPeer,
 } from './types';
 
 import { DailyCall } from '@daily-co/daily-js';
@@ -309,21 +310,24 @@ export default class DailyVCSWebRenderer {
 
     this.applyTracks([...videos, ...screens]);
 
-    const peers = filteredParticipants.map((p) => ({
-      id: p.session_id,
-      displayName: p.user_name || 'Guest',
-      video: {
-        id: p?.tracks?.video?.track?.id ?? '',
-        paused: isTrackOff(p?.tracks?.video?.state),
-      },
-      audio: {},
-      screenshareVideo: {
-        id: p?.tracks?.screenVideo?.track?.id ?? '',
-        paused: isTrackOff(p?.tracks?.screenVideo?.state),
-      },
-      screenshareAudio: {},
-    }));
-    this.vcsApi.setRoomPeers(peers);
+    const peers = new Map<string, VCSPeer>();
+    filteredParticipants.forEach((p) => {
+      peers.set(p.session_id, {
+        id: p.session_id,
+        displayName: p.user_name || 'Guest',
+        video: {
+          id: p?.tracks?.video?.track?.id ?? '',
+          paused: isTrackOff(p?.tracks?.video?.state),
+        },
+        audio: {},
+        screenshareVideo: {
+          id: p?.tracks?.screenVideo?.track?.id ?? '',
+          paused: isTrackOff(p?.tracks?.screenVideo?.state),
+        },
+        screenshareAudio: {},
+      });
+    });
+    this.vcsApi.setRoomPeerDescriptionsById(peers);
   }
 
   private setupEventListeners() {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -59,7 +59,7 @@ export interface VCSApi {
   setScaleFactor(scaleFactor: number): void;
   stop(): void;
   updateImageSources(sources: VCSSources): void;
-  setRoomPeers(peers: VCSPeer[]): void;
+  setRoomPeerDescriptionsById(peers: Map<string, VCSPeer>): void;
 }
 
 export interface VCSComposition {

--- a/tests/VCSWebRenderer.test.ts
+++ b/tests/VCSWebRenderer.test.ts
@@ -11,7 +11,7 @@ const mockVCSApi: VCSApi = {
   setActiveVideoInputSlots: jest.fn(),
   setParamValue: jest.fn(),
   setScaleFactor: jest.fn(),
-  setRoomPeers: jest.fn(),
+  setRoomPeerDescriptionsById: jest.fn(),
   updateImageSources: jest.fn(),
   stop: jest.fn(),
 };
@@ -241,7 +241,9 @@ describe('VCSWebRenderer', () => {
       },
     ]);
 
-    expect(renderer.vcsApiInstance!.setRoomPeers).toHaveBeenCalled();
+    expect(
+      renderer.vcsApiInstance!.setRoomPeerDescriptionsById
+    ).toHaveBeenCalled();
     expect(renderer.vcsApiInstance!.updateImageSources).toHaveBeenCalled();
     expect(
       renderer.vcsApiInstance!.setActiveVideoInputSlots


### PR DESCRIPTION
This PR is to use `setRoomPeerDescriptionsById` instead of `setRoomPeers`, it's an upstream change (vcs composition)