### PR TITLE
avoid making calls to handleParticipantsChange when vcs has not yet started

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -97,3 +97,5 @@ export interface Options {
 }
 
 export type Merge = 'replace' | 'merge';
+
+export type State = 'idle' | 'started' | 'stopped' | 'error';


### PR DESCRIPTION
This PR is to avoid calling handleParticipantsChange when vcs didn't yet start.