### PR TITLE
allow to call sendParams even before starting the VCS instance

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     }
   ],
   "devDependencies": {
-    "@daily-co/daily-js": "^0.47.0",
+    "@daily-co/daily-js": ">=0.47.0",
     "@rollup/plugin-commonjs": "^25.0.2",
     "@rollup/plugin-node-resolve": "^15.1.0",
     "@rollup/plugin-terser": "^0.4.3",

--- a/src/VCSWebRenderer.ts
+++ b/src/VCSWebRenderer.ts
@@ -404,12 +404,7 @@ export default class DailyVCSWebRenderer {
     this.setupEventListeners();
 
     this.sendActiveVideoInputSlots();
-
-    if (this.defaultParams) {
-      for (const key in this.defaultParams) {
-        this.sendParam(key, this.defaultParams[key]);
-      }
-    }
+    this.sendParams({ ...this.paramValues, ...this.defaultParams });
 
     this.rootDisplaySizeChanged();
     this.callbacks.onStart?.();
@@ -472,21 +467,19 @@ export default class DailyVCSWebRenderer {
    * @param value
    */
   sendParam(paramId: string, value: any) {
-    if (!this.vcsApi) return;
-
-    this.vcsApi.setParamValue(paramId, value);
+    if (this.vcsApi) {
+      this.vcsApi.setParamValue(paramId, value);
+      this.callbacks.onParamsChanged?.(this.paramValues);
+    }
 
     // retain a copy of param values so we can reset renderer to the same state
     this.paramValues[paramId] = value;
-    this.callbacks.onParamsChanged?.(this.paramValues);
   }
 
   /**
    * sendParams sends a map of param updates to the VCS composition.
    */
   sendParams(params: Record<string, any>, mergeType: Merge = 'merge') {
-    if (!this.vcsApi) return;
-
     if (mergeType === 'replace') this.paramValues = {};
     Object.entries(params).forEach(([id, value]) => this.sendParam(id, value));
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -315,10 +315,10 @@
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
 
-"@daily-co/daily-js@^0.47.0":
-  version "0.47.0"
-  resolved "https://registry.yarnpkg.com/@daily-co/daily-js/-/daily-js-0.47.0.tgz#6a446ebc05bbd60e879edcb5cffded54fb57fa4b"
-  integrity sha512-9RtKtgSUiTd3mTqcvfsr6COYJWIKL7cDk8hmqeE6WW9eoWIBOx0PWGjt8QhvnLHsG8IPkbSYH8KQQPAm4pf99g==
+"@daily-co/daily-js@>=0.47.0":
+  version "0.49.1"
+  resolved "https://registry.yarnpkg.com/@daily-co/daily-js/-/daily-js-0.49.1.tgz#e00f7703a031a31cf6363da057b641a27962bb3c"
+  integrity sha512-Nm2KdNt75v/TDVuV4ddExWaX7YuVxBa3taHcomjn4dbSypCWO/xLsW+8ykOtV2puKmEe5qKZk3BSPTw/C8wbLA==
   dependencies:
     "@babel/runtime" "^7.12.5"
     bowser "^2.8.1"


### PR DESCRIPTION
This PR will allow to call `sendParams` even before starting the VCS instance.